### PR TITLE
Prep for v0.7 release

### DIFF
--- a/META
+++ b/META
@@ -1,3 +1,3 @@
 Name:       lua-hostlist
-Version:    0.6
+Version:    0.7
 Release:    1

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+Version 0.7 (2025-08-27):
+- More fixes for RHEL 9 and Lua 5.4 compatibility.
+
 Version 0.6 (2025-03-07):
 - Tag latest release for Lua 5.4 compatibility.
 


### PR DESCRIPTION
Problem: The META and NEWS files are not updated for v0.7.

Update them.